### PR TITLE
Fix ping reactivating when changing target

### DIFF
--- a/NRM.plugin.js
+++ b/NRM.plugin.js
@@ -4,38 +4,34 @@
  * @author somebody
  * @authorId 153146360705712128
  * @authorLink https://github.com/somebody1234
- * @version 0.0.2
- * @source https://raw.githubusercontent.com/somebody1234/userscripts/master/NRM.plugin.js
- * @updateUrl https://raw.githubusercontent.com/somebody1234/userscripts/master/NRM.plugin.js
+ * @version 0.0.3
+ * @source https://github.com/BetterDiscordPlugins/userscripts/blob/master/NRM.plugin.js
+ * @updateUrl https://raw.githubusercontent.com/BetterDiscordPlugins/userscripts/master/NRM.plugin.js
  */
 module.exports = class NoReplyMention {
-  constructor() {
-    const {Webpack, Webpack: {Filters}} = BdApi;
-
-    [this.i18n, this.classes] = Webpack.getBulk(
-      {filter: m => m.getLocale && m.Messages?.REPLY_MENTION_ON},
-      {filter: Filters.byProps("mentionButton")}
-    );
+  constructor(meta) {
+    this.api = new BdApi(meta.name);
+    const { Filters } = this.api.Webpack;
+    this.replyBar = this.getModuleAndKey(Filters.byStrings(".shouldMention", ".showMentionToggle"))
+    if (!this.replyBar) console.error("NoReplyMention: Could not find reply bar module");
   }
-  
-  start() {}
-  stop() {}
-  
-  observer({addedNodes}) {
-    if (!this.i18n || !this.classes) return;
-    
-    for (const node of addedNodes) {
-      if (node.nodeType === Node.TEXT_NODE) continue;
 
-      const elements = node.getElementsByClassName(this.classes.mentionButton);
+  getModuleAndKey(filter) {
+    const { getModule } = this.api.Webpack;
+    let module;
+    const value = getModule((e, m) => filter(e) ? (module = m) : false, { searchExports: true });
+    if (!module) return;
+    return [module.exports, Object.keys(module.exports).find(k => module.exports[k] === value)];
+  }
 
-      if (!elements.length) continue;
-      
-      for (const element of elements) {
-        if (element.textContent === this.i18n.Messages.REPLY_MENTION_ON) {
-          element.click();
-        }
-      }
-    }  
+  start() {
+    const { Patcher } = this.api;
+    Patcher.before(...this.replyBar, (_thisArg, [props]) => {
+      props.shouldMention = false;
+    });
+  }
+  stop() {
+    const { Patcher } = this.api;
+    Patcher.unpatchAll();
   }
 }


### PR DESCRIPTION
This fixes the ping being reactivated when initiating a reply to a message while the reply bar is already showing. This happens when you change the message you wanna reply to without explicitly canceling the reply. In fact even right-click + reply on the same message you are already replying to would cause the ping to reactivate.

I've also updated the source url (and updateUrl, not that it would matter) to point to this repo instead, as the upstream repo is behind and isn't updating anymore. Didn't really feel comfortable with changing the author too.